### PR TITLE
config: fix up opencv version compatibility

### DIFF
--- a/include/easypr/config.h
+++ b/include/easypr/config.h
@@ -1,8 +1,6 @@
 #ifndef EASYPR_CONFIG_H_
 #define EASYPR_CONFIG_H_
 
-#define CV_VERSION_THREE_ZERO
-
 namespace easypr {
 
   enum Color { BLUE, YELLOW, WHITE, UNKNOWN };
@@ -131,7 +129,7 @@ private:\
   }
 
 // Load model. compatitable withe 3.0, 3.1 and 3.2
-#ifdef CV_VERSION_THREE_TWO
+#if (CV_VERSION_MAJOR >= 3) && (CV_VERSION_MINOR >= 2)
   #define LOAD_SVM_MODEL(model, path) \
     model = ml::SVM::load(path);
   #define LOAD_ANN_MODEL(model, path) \


### PR DESCRIPTION
Fix up errors like https://github.com/liuruoze/EasyPR/issues/152

EasyPR/src/core/chars_identify.cpp:22:3: error: expected '(' for function-style cast or type construction
  LOAD_ANN_MODEL(ann_, kDefaultAnnPath);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
EasyPR/include/easypr/config.h:141:42: note: expanded from macro 'LOAD_ANN_MODEL'
    model = ml::ANN_MLP::load<ml::ANN_MLP>(path);
                              ~~~~~~~~~~~^

Tested in Mac OSX with opencv 3.4.1.

Signed-off-by: Wu Zhangjin <wuzhangjin@gmail.com>