### PR TITLE
CMakeLists.txt: mac: use default opencv install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
-    set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "/usr/local/opt/opencv-3.2.0")
+    set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "/usr/local/opt/opencv")
 endif ()
 
 # OpenVC3 required


### PR DESCRIPTION
the 'brew' command installs a default symbol link: /usr/local/opt/opencv for any new
installed opencv version, using it instead of the one with version number is
better, because it avoids modifying this setting manually.

Signed-off-by: Wu Zhangjin <wuzhangjin@gmail.com>